### PR TITLE
Test workflow enhancements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,134 @@
+name: Test mqtt2kasa
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      branch_or_commit:
+        description: 'Branch or commit to run the workflow on'
+        required: true
+        default: main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      VM_MEMORY: 512
+      VM_CPUS: 2
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.event.inputs.branch_or_commit }}
+
+      - name: Unset GitHub extraheader
+        run: git config --unset-all http.https://github.com/.extraheader || true
+
+      - name: Set up environment
+        run: |
+          echo id
+          id
+          pwd -P
+          ls -la
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository -y ppa:deadsnakes/ppa
+          sudo apt-get install -y python3.10 python3.10-venv
+          sudo apt-get install -y mosquitto-clients
+          sudo ln -sf /usr/bin/python3.10 /usr/bin/python3
+
+      - name: Set up vagrant user
+        run: |
+          # Create vagrant group and user with sudo powers
+          sudo groupadd vagrant
+          sudo useradd --gid vagrant --groups vagrant,users,adm --shell /bin/bash --create-home vagrant
+          echo 'vagrant ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/90-vagrant
+
+          # Set up /vagrant directory. It is a mount to the cloned repo
+          sudo mkdir -pv /vagrant
+          sudo chown vagrant:vagrant /vagrant
+          sudo chown -R vagrant:vagrant "${GITHUB_WORKSPACE}"
+          sudo mount --bind "${GITHUB_WORKSPACE}" /vagrant
+
+          echo Mounted "${GITHUB_WORKSPACE}" as /vagrant
+          ls /vagrant
+
+      - name: Install mqtt2kasa
+        run: |
+          sudo -u vagrant -i <<'EOF'
+          /vagrant/mqtt2kasa/bin/create-env.sh
+          file /vagrant/env/bin
+          source /vagrant/env/bin/activate
+          pip install --upgrade pip
+          echo '[ -e /vagrant/env/bin/activate ] && source /vagrant/env/bin/activate' >> ~vagrant/.bashrc
+          ln -s /vagrant/data/config.yaml.vagrant ~vagrant/mqtt2kasa.config.yaml
+          sudo cp -v /vagrant/mqtt2kasa/bin/mqtt2kasa.service.vagrant /lib/systemd/system/mqtt2kasa.service
+          ln -s /vagrant/mqtt2kasa/bin/tail_log.sh ~vagrant/
+          ln -s /vagrant/mqtt2kasa/bin/reload_config.sh ~vagrant/
+          ln -s /vagrant/mqtt2kasa/tests/basic_test.sh.vagrant ~vagrant/basic_test.sh
+          EOF
+
+      - name: Create Mosquitto conf
+        run: |
+          echo "allow_anonymous true
+          listener 1883 0.0.0.0
+          log_type all
+          log_dest stdout" | tee /tmp/mosquitto.conf
+          echo using secondary address 192.168.123.123 as the mqtt broker
+          sudo ip a add 192.168.123.123/32 dev eth0
+
+      - name: Start Mosquitto
+        uses: namoshek/mosquitto-github-action@v1
+        with:
+          version: '1.6'
+          ports: '1883:1883 8883:8883'
+          config: /tmp/mosquitto.conf
+          container-name: 'mqtt'
+
+      - name: Install tplink-smarthome-simulator
+        run: |
+          sudo -u vagrant -i <<'EOF'
+          cd ~vagrant
+          if [ ! -d "tplink-smarthome-simulator" ]; then
+            sudo apt-get install -y nodejs npm git
+            git clone https://github.com/flavio-fernandes/tplink-smarthome-simulator.git
+            cd tplink-smarthome-simulator
+            npm install
+            for x in {201..204}; do
+              sudo ip a add 192.168.123.${x}/32 dev eth0
+            done
+            sudo cp -v /vagrant/mqtt2kasa/tests/simulator.js.vagrant ./test/simulator.js
+            sudo cp -v /vagrant/mqtt2kasa/tests/tplink-smarthome-simulator.service.vagrant /lib/systemd/system/tplink-smarthome-simulator.service
+          fi
+          EOF
+
+      - name: Start tplink-smarthome-simulator and mqtt2kasa services
+        run: |
+          sudo systemctl enable --now tplink-smarthome-simulator.service
+          sudo systemctl enable --now mqtt2kasa.service
+
+      - name: Check services and ports
+        run: |
+          echo ----
+          sudo ip route
+          sudo ss -plnt
+          echo ----
+          sudo systemctl status --full --no-pager tplink-smarthome-simulator.service
+          sudo journalctl -xeu tplink-smarthome-simulator.service
+          echo ----
+          sudo systemctl status --full --no-pager mqtt2kasa.service
+          sudo journalctl -xeu mqtt2kasa.service
+          echo ----
+          sudo docker logs mqtt
+
+      - name: Run Tests
+        run: |
+          sudo -u vagrant -i <<'EOF'
+          cd ~vagrant
+          ./basic_test.sh
+          # that was fun. do it again
+          ./basic_test.sh
+          EOF

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,17 +7,19 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.require_version ">=1.7.0"
 
 $bootstrap_ubuntu = <<SCRIPT
+export DEBIAN_FRONTEND=noninteractive
 # apt-get update && sudo apt-get -y upgrade && sudo apt-get -y dist-upgrade
-apt update
-apt install -y software-properties-common
+apt-get update
+apt-get install -y software-properties-common
 add-apt-repository -y ppa:deadsnakes/ppa
-apt install -y python3.7 python3.7-venv
-ln -sf python3.7 /usr/bin/python3
+apt-get install -y python3.10 python3.10-venv
+ln -sf python3.10 /usr/bin/python3
 
 SCRIPT
 
 $install_mosquitto = <<SCRIPT
-apt install -y mosquitto mosquitto-clients
+export DEBIAN_FRONTEND=noninteractive
+apt-get install -y mosquitto mosquitto-clients
 
 cat <<EOT > /etc/mosquitto/conf.d/localbroker.conf
 allow_anonymous true
@@ -47,7 +49,8 @@ SCRIPT
 $test_mqtt2kasa = <<SCRIPT
 [ -d 'tplink-smarthome-simulator' ] || {
     pushd ~/
-    sudo apt install -y nodejs npm git
+    export DEBIAN_FRONTEND=noninteractive
+    sudo apt-get install -y nodejs npm git
     git clone https://github.com/flavio-fernandes/tplink-smarthome-simulator.git
     cd tplink-smarthome-simulator
     npm install

--- a/mqtt2kasa/tests/basic_test.sh.vagrant
+++ b/mqtt2kasa/tests/basic_test.sh.vagrant
@@ -60,7 +60,7 @@ get_log_lines
 grep --quiet -E 'Mqtt event causing device foo to be set as on' ${TMP_OUTPUT} || \
   { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
 get_simulator_lines
-grep --quiet -E 'set_relay_state.*"state": 1' ${TMP_OUTPUT} || \
+grep --quiet -E 'set_relay_state.*"state":\s*1' ${TMP_OUTPUT} || \
   { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
 grep --quiet -E '192\.168\.123\.201' ${TMP_OUTPUT} || \
   { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
@@ -72,7 +72,7 @@ get_log_lines
 grep --quiet -E 'Mqtt event causing device lar to be set as off' ${TMP_OUTPUT} || \
   { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
 get_simulator_lines
-grep --quiet -E 'set_relay_state.*"state": 0' ${TMP_OUTPUT} || \
+grep --quiet -E 'set_relay_state.*"state":\s*0' ${TMP_OUTPUT} || \
   { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
 grep --quiet -E '192\.168\.123\.203' ${TMP_OUTPUT} || \
   { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
@@ -80,17 +80,19 @@ grep --quiet -E '"err_code":0' ${TMP_OUTPUT} || \
   { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
 
 echo TEST: Check brightness
-mosquitto_pub -h ${MQTT_BROKER} -t /dimmer/brightness -m "77"
-get_log_lines
-grep --quiet -E 'Mqtt event causing device dimmer\(\/dimmer\/brightness\) to be set as 77' ${TMP_OUTPUT} || \
-  { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
-get_simulator_lines
-grep --quiet -E 'set_brightness.*"brightness": 77' ${TMP_OUTPUT} || \
-  { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
-grep --quiet -E '192\.168\.123\.204' ${TMP_OUTPUT} || \
-  { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
-grep --quiet -E 'set_brightness.*"err_code":0' ${TMP_OUTPUT} || \
-  { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }  
+for brightness in 25 77; do
+  mosquitto_pub -h ${MQTT_BROKER} -t /dimmer/brightness -m ${brightness}
+  get_log_lines
+  grep --quiet -E 'Mqtt event causing device dimmer\(\/dimmer\/brightness\) to be set as '"${brightness}" ${TMP_OUTPUT} || \
+    { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
+  get_simulator_lines
+  grep --quiet -E 'set_brightness.*"brightness":\s*'"${brightness}" ${TMP_OUTPUT} || \
+    { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
+  grep --quiet -E '192\.168\.123\.204' ${TMP_OUTPUT} || \
+    { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
+  grep --quiet -E 'set_brightness.*"err_code":0' ${TMP_OUTPUT} || \
+    { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
+done
 
 echo 'PASSED: Happy happy, joy joy!'
 rm -f ${TMP_OUTPUT}


### PR DESCRIPTION
Found some time to play this weekend! Please let me know what you think.

- Add workflow to exercise basic_test.sh upon pull requests
- Use Python 3.10 instead of 3.7.
- Use "apt-get" to avoid the "apt does not have a stable CLI interface" warning.
- Adjust regex to allow cases when there are no spaces in a specific log message.
- Use multiple brightness values so the test can be run back to back.

Best,

-- flaviof
